### PR TITLE
Add support for supplying multiple contexts.

### DIFF
--- a/kubetail
+++ b/kubetail
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 KUBECTL_BIN=${KUBECTL_BIN:-"kubectl"}
 
@@ -38,6 +38,7 @@ where:
     -c, --container      The name of the container to tail in the pod (if multiple containers are defined in the pod).
                          Defaults to all containers in the pod. Can be used multiple times.
     -t, --context        The k8s context. ex. int1-context. Relies on ~/.kube/config for the contexts.
+		                     Several contexts can be supplied, separated by commas.
     -l, --selector       Label selector. If used the pod name is ignored.
     -n, --namespace      The Kubernetes namespace where the pods are located (defaults to \"default\")
     -d, --dry-run        Print the names of the matched pods and containers, then exit.
@@ -90,7 +91,7 @@ if [ "$#" -ne 0 ]; then
 			regex="regex"
 			;;
 		-t|--context)
-			context="$2"
+			contexts=`echo "$2" | sed 's/,/ /g'`
 			;;
 		-r|--cluster)
 			cluster="--cluster $2"
@@ -208,8 +209,16 @@ if [ "${regex}" == 'regex' ]; then
 fi
 
 # Get all pods matching the input and put them in an array. If no input then all pods are matched.
-matching_pods=(`${KUBECTL_BIN} get pods ${context:+--context=${context}} "${selector[@]}" --namespace=${namespace} ${cluster} --output=jsonpath='{.items[*].metadata.name}' | xargs -n1 | grep $grep_matcher "${pod}"`)
-matching_pods_size=${#matching_pods[@]}
+declare -A matching_pods
+matching_pods_size=0
+if [[ -z ${contexts} ]]; then
+	contexts=(`${KUBECTL_BIN} config current-context`)
+fi
+for context in ${contexts[@]}; do
+	pods=(`${KUBECTL_BIN} get pods ${context:+--context=${context}} "${selector[@]}" --namespace=${namespace} ${cluster} --output=jsonpath='{.items[*].metadata.name}' | xargs -n1 | grep $grep_matcher "${pod}"`)
+	matching_pods[${context}]="${pods[@]}"
+	matching_pods_size=$((matching_pods_size + ${#pods[@]}))
+done
 
 if [ ${matching_pods_size} -eq 0 ]; then
 	echo "No pods exists that matches ${pod}"
@@ -247,44 +256,46 @@ function kill_kubectl_processes {
 # the temporary file in these cases as well.
 trap kill_kubectl_processes EXIT
 
-for pod in ${matching_pods[@]}; do
-	if [ ${#containers[@]} -eq 0 ]; then
-		pod_containers=($(${KUBECTL_BIN} get pod ${pod} ${context:+--context=${context}} --output=jsonpath='{.spec.containers[*].name}' --namespace=${namespace} ${cluster} | xargs -n1))
-	else
-		pod_containers=("${containers[@]}")
-	fi
-
-	for container in ${pod_containers[@]}; do
-		if [ ${colored_output} == "false" ] || [ ${matching_pods_size} -eq 1 -a ${#pod_containers[@]} -eq 1 ]; then
-			color_start=$(tput sgr0)
+for context in ${!matching_pods[@]}; do
+	for pod in ${matching_pods[${context}]}; do
+		if [ ${#containers[@]} -eq 0 ]; then
+			pod_containers=($(${KUBECTL_BIN} get pod ${pod} ${context:+--context=${context}} --output=jsonpath='{.spec.containers[*].name}' --namespace=${namespace} ${cluster} | xargs -n1))
 		else
-			color_index=`next_col $color_index`
-			color_start=$(tput setaf $color_index)
+			pod_containers=("${containers[@]}")
 		fi
 
-		if [ ${#pod_containers[@]} -eq 1 ]; then
-			display_name="${pod}"
-		else
-			display_name="${pod} ${container}"
-		fi
-		display_names_preview+=("${color_start}${display_name}${color_end}")
+		for container in ${pod_containers[@]}; do
+			if [ ${colored_output} == "false" ] || [ ${matching_pods_size} -eq 1 -a ${#pod_containers[@]} -eq 1 ]; then
+				color_start=$(tput sgr0)
+			else
+				color_index=`next_col $color_index`
+				color_start=$(tput setaf $color_index)
+			fi
 
-		if [ ${colored_output} == "pod" ]; then
-			colored_line="${color_start}[${display_name}]${color_end} \$line"
-		else
-			colored_line="${color_start}[${display_name}] \$line ${color_end}"
-		fi
+			if [ ${#pod_containers[@]} -eq 1 ]; then
+				display_name="${pod}"
+			else
+				display_name="${pod} ${container}"
+			fi
+			display_names_preview+=("${color_start}${display_name}${color_end}")
 
-		kubectl_cmd="${KUBECTL_BIN} ${context:+--context=${context}} logs ${pod} ${container} -f --since=${since} --tail=${tail} --namespace=${namespace} ${cluster}"
-		colorify_lines_cmd="while read line; do echo \"$colored_line\" | tail -n +1; done"
-		if [ "z" == "z$jq_selector" ]; then
-			logs_commands+=("${kubectl_cmd} ${timestamps} | ${colorify_lines_cmd}");
-		else
-			logs_commands+=("${kubectl_cmd} | jq --unbuffered -r -R --stream '. | fromjson? | $jq_selector ' | ${colorify_lines_cmd}");
-		fi
+			if [ ${colored_output} == "pod" ]; then
+				colored_line="${color_start}[${display_name}]${color_end} \$line"
+			else
+				colored_line="${color_start}[${display_name}] \$line ${color_end}"
+			fi
 
-		# There are only 11 usable colors
-		i=$(( ($i+1)%13 ))
+			kubectl_cmd="${KUBECTL_BIN} ${context:+--context=${context}} logs ${pod} ${container} -f --since=${since} --tail=${tail} --namespace=${namespace} ${cluster}"
+			colorify_lines_cmd="while read line; do echo \"$colored_line\" | tail -n +1; done"
+			if [ "z" == "z$jq_selector" ]; then
+				logs_commands+=("${kubectl_cmd} ${timestamps} | ${colorify_lines_cmd}");
+			else
+				logs_commands+=("${kubectl_cmd} | jq --unbuffered -r -R --stream '. | fromjson? | $jq_selector ' | ${colorify_lines_cmd}");
+			fi
+
+			# There are only 11 usable colors
+			i=$(( ($i+1)%13 ))
+		done
 	done
 done
 


### PR DESCRIPTION
Multiple contexts can be provided with the [-t|--context] option now.
Examples:
```
# Uses the current context
kubetail -l app_group=gov

# Provide a context
kubetail -l app_group=gov -t minikube

# Provide multiple contexts. Uses contexts ostrich3b and ostrich3d
kubetail -l app_group=gov -t ostrich3b,ostrich3d
```